### PR TITLE
Fix: Convert AnyUrl to str in handle_read_resource()

### DIFF
--- a/src/crowdsec_local_mcp/mcp_core.py
+++ b/src/crowdsec_local_mcp/mcp_core.py
@@ -222,7 +222,10 @@ async def handle_list_resources() -> list[types.Resource]:
 @server.read_resource()
 async def handle_read_resource(uri: str) -> str:
     LOGGER.info("Reading resource content for %s", uri)
-    reader = REGISTRY.get_resource_reader(uri)
+    # The MCP framework passes an AnyUrl object at runtime, not a str.
+    # Convert to str so the lookup matches the string keys in _resource_readers.
+    uri_str = str(uri)
+    reader = REGISTRY.get_resource_reader(uri_str)
     return reader()
 
 


### PR DESCRIPTION
Fixes #34

## Problem

The MCP framework passes `uri` as a `pydantic.networks.AnyUrl` object at runtime, not a `str`. The `_resource_readers` dictionary uses string keys (set during registration), so the lookup fails with "Unknown resource".

## Fix

Convert the `AnyUrl` object to a string before looking up the resource reader.

## Changes

- `src/crowdsec_local_mcp/mcp_core.py`: Convert `uri` to `str()` in `handle_read_resource()`
